### PR TITLE
version bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>multi-table-plugins</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.0</version>
   <packaging>jar</packaging>
 
   <name>Multiple Table Plugins</name>


### PR DESCRIPTION
```
[WARNING] Bundle io.cdap.plugin:multi-table-plugins:jar:1.2.0 : Export org.apache.orc.mapreduce,  has 1,  private references [org.apache.hadoop.hive.ql.io.sarg], 
[WARNING] Bundle io.cdap.plugin:multi-table-plugins:jar:1.2.0 : Export org.apache.orc.tools,  has 1,  private references [org.codehaus.jettison.json], 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 22.191 s
[INFO] Finished at: 2020-07-16T13:41:00-07:00
[INFO] ------------------------------------------------------------------------
