### PR TITLE
[Fixit Q4 2022] Bump hadoop version and exclude log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cdap.version>6.8.0-SNAPSHOT</cdap.version>
-    <hadoop.version>2.3.0</hadoop.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <hsql.version>2.2.4</hsql.version>
     <hydrator.version>2.9.0-SNAPSHOT</hydrator.version>
     <!-- properties for script build step that creates the config files for the artifacts -->
@@ -81,6 +81,12 @@
       <artifactId>hydrator-test</artifactId>
       <version>${cdap.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
The indirect log4j dependency can be excluded in cdap-explore, since it is disabled in the tests.

No more log4j indirect dependency:
<img width="594" alt="1" src="https://user-images.githubusercontent.com/114443254/208213479-ca165c4c-e5e1-4eb6-bb8b-993715df97e0.png">

Unit tests still pass:
<img width="378" alt="2" src="https://user-images.githubusercontent.com/114443254/208213668-19bce874-e502-4af8-9df2-ba6eef633ca5.png">
