### PR TITLE
Bump develop branch to next minor version v1.5.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>multi-table-plugins</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.5.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Multiple Table Plugins</name>


### PR DESCRIPTION
Bump develop branch to next minor version v1.5.0-SNAPSHOT

v1.4.x are being tracked in branch [release/1.4](https://github.com/data-integrations/multi-table-plugins/tree/release/1.4)
Latest version available on hub is v1.4.0