### PR TITLE
[PLUGIN-1950] : Log zero records for Table mode and SQL Statement mode.

### DIFF
--- a/src/main/java/io/cdap/plugin/format/DBTableRecordReader.java
+++ b/src/main/java/io/cdap/plugin/format/DBTableRecordReader.java
@@ -24,6 +24,8 @@ import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -38,6 +40,8 @@ import java.util.List;
  * Record reader that reads the entire contents of a database table using JDBC.
  */
 public class DBTableRecordReader extends RecordReader<NullWritable, RecordWrapper> {
+  private static final Logger LOG = LoggerFactory.getLogger(DBTableRecordReader.class);
+
   private final DBTableName tableName;
   private final String tableNameField;
   private final MultiTableConf dbConf;
@@ -85,6 +89,10 @@ public class DBTableRecordReader extends RecordReader<NullWritable, RecordWrappe
         schema = Schema.recordOf(tableName.getTable(), schemaFields);
       }
       if (!results.next()) {
+        if (pos == 0 && DBTableSplit.DEFAULT_CLAUSE.equals(split.getLowerClause())
+          && DBTableSplit.DEFAULT_CLAUSE.equals(split.getUpperClause())) {
+          LOG.info("Source table '{}' has zero records.", tableName.fullTableName());
+        }
         return false;
       }
 

--- a/src/main/java/io/cdap/plugin/format/DBTableSplit.java
+++ b/src/main/java/io/cdap/plugin/format/DBTableSplit.java
@@ -26,7 +26,7 @@ import java.io.IOException;
  * A split representing data in a database table.
  */
 public class DBTableSplit extends DataDrivenDBInputFormat.DataDrivenDBInputSplit {
-  private static final String DEFAULT_CLAUSE = "1=1";
+  public static final String DEFAULT_CLAUSE = "1=1";
 
   private DBTableName tableName;
 

--- a/src/main/java/io/cdap/plugin/format/MultiTableDBInputFormat.java
+++ b/src/main/java/io/cdap/plugin/format/MultiTableDBInputFormat.java
@@ -196,6 +196,9 @@ public class MultiTableDBInputFormat extends InputFormat<NullWritable, RecordWra
                                                                          columnName,
                                                                          conf.getPluginConf().getWhereClause()))) {
       results.next();
+      if (results.getObject(1) == null && results.getObject(2) == null) {
+        return Collections.singletonList(new DBTableSplit(info.getDbTableName()));
+      }
 
       // Based on the type of the results, use a different mechanism
       // for interpolating split points (i.e., numeric splits, text splits,

--- a/src/main/java/io/cdap/plugin/format/SQLStatementRecordReader.java
+++ b/src/main/java/io/cdap/plugin/format/SQLStatementRecordReader.java
@@ -89,6 +89,9 @@ public class SQLStatementRecordReader extends RecordReader<NullWritable, RecordW
         schema = Schema.recordOf(tableName, schemaFields);
       }
       if (!results.next()) {
+        if (pos == 0) {
+          LOG.info("SQL statement '{}' ('{}') has zero records.", split.getId(), split.getSqlStatement());
+        }
         return false;
       }
 


### PR DESCRIPTION
# Add Logging for Empty Tables and Queries in Multi-Table Plugins

## Problem
When reading from multiple database tables or executing multiple SQL statements, there is currently no visibility into which tables or queries yielded zero records.

## Solution
This PR adds informational logging whenever an ingestion source (table or custom query) produces exactly zero records.

### Key Changes

1. **Empty Table Detection in Multi-Table Mode**:
   - **`MultiTableDBInputFormat`**: Updated `getTableSplits` to explicitly detect when a table is empty (bounding query returns `NULL, NULL`) and return exactly one full-table split (`1=1`).
   - **`DBTableRecordReader`**: Added logging to emit `Source table '<fullTableName>' has zero records.` when exactly zero rows are read. Verified that the reader is processing a full-table split (`1=1`) to prevent false alarms on empty partial splits when `splitsPerTable > 1`.

2. **Improved Logging in SQL Statement Mode**:
   - **`SQLStatementRecordReader`**: Added logging to emit `SQL statement '<id>' ('<query>') has zero records.` when exactly zero rows are read.

### Testing 

1. Verified in CDAP Sandbox that it is able to log the statement for Empty Table  with splits = 4 
<img width="983" height="345" alt="Screenshot 2026-05-15 at 5 24 52 PM" src="https://github.com/user-attachments/assets/3fa0d13f-9f44-400b-b5b6-ab4e373f71f0" />

2. Verified in CDAP Sandbox that it is able to log the statement for SQL statement mode 
<img width="1283" height="393" alt="Screenshot 2026-05-15 at 5 34 57 PM" src="https://github.com/user-attachments/assets/e703de6f-2ec2-4116-8ab2-9df3ee8a6a52" />

3. Also verified that in case of Proper data, it is not printing this LOG LINE. 

4. Verified in PROD environment as well. 
